### PR TITLE
adding nodemon support

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,11 @@
 {
 "name": "ef7osxtest",
 "version": "0.0.0",
+"devDependencies": {
+    "nodemon": "1.9.1",
+    "gulp": "3.9.1",
+    "gulp-cli": "1.2.1"
+},
 "scripts": {
      "start" : "nodemon --ignore htm,html --ext cs,js --exec \"dnx web ASPNET_ENV=Development\" -V"
    }

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,7 @@
+{
+"name": "ef7osxtest",
+"version": "0.0.0",
+"scripts": {
+     "start" : "nodemon --ignore htm,html --ext cs,js --exec \"dnx web ASPNET_ENV=Development\" -V"
+   }
+}


### PR DESCRIPTION
```
npm install
```

then run 

```
npm start
```

I have also started setting the `ASPNET_ENV=Development`, the nightlies started to break under Production setting.

additonal changes per @csharpfritz 
